### PR TITLE
Added quick ways to open JSON Editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,22 @@
             {
                 "command": "vscode-json-editor.start",
                 "title": "Start JSON editor session",
-                "category": "JSON editor"
+                "category": "JSON editor",
+                "icon": {
+                    "light": "./resources/json-light.svg",
+                    "dark": "./resources/json-dark.svg"
+                }
             }
         ],
+        "menus": {
+            "editor/title": [
+                {
+                    "when": "editorLangId == json",
+                    "command": "vscode-json-editor.start",
+                    "group": "navigation"
+                }
+            ]
+        },
         "configuration": {
             "title": "Json Editor",
             "properties": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,13 @@
             }
         ],
         "menus": {
+            "explorer/context": [
+                {
+                    "when": "resourceExtname == .json",
+                    "command": "vscode-json-editor.start",
+                    "group": "navigation"
+                }
+            ],
             "editor/title": [
                 {
                     "when": "editorLangId == json",

--- a/resources/json-dark.svg
+++ b/resources/json-dark.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="96"
+   height="96"
+   viewBox="0 0 25.4 25.400001"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="json-dark.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#3c3c3c"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6"
+     inkscape:cx="-25.825627"
+     inkscape:cy="57.405052"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="2560"
+     inkscape:window-height="1380"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     width="96in" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-271.6)">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.11811638px;line-height:1.25;font-family:'Amatic SC';-inkscape-font-specification:'Amatic SC';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.58464646"
+       x="-1.492721"
+       y="239.32918"
+       id="text819"
+       transform="scale(0.82191975,1.2166638)"><tspan
+         sodipodi:role="line"
+         id="tspan817"
+         x="-1.492721"
+         y="239.32918"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold';fill:#ffffff;fill-opacity:1;stroke-width:3.58464646">{ }</tspan></text>
+  </g>
+</svg>

--- a/resources/json-light.svg
+++ b/resources/json-light.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="96"
+   height="96"
+   viewBox="0 0 25.4 25.400001"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="json-light.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6"
+     inkscape:cx="-2.9694961"
+     inkscape:cy="64.211529"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="2560"
+     inkscape:window-height="1380"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-271.59998)">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.37059402px;line-height:1.25;font-family:'Amatic SC';-inkscape-font-specification:'Amatic SC';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.6319859"
+       x="-1.6392481"
+       y="239.59866"
+       id="text819"
+       transform="scale(0.82191975,1.2166638)"><tspan
+         sodipodi:role="line"
+         id="tspan817"
+         x="-1.6392481"
+         y="239.59866"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold';stroke-width:3.6319859">{ }</tspan></text>
+  </g>
+</svg>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,9 +7,29 @@ import { JsonEditorPanel } from './JsonEditorPanel';
 // tslint:disable-next-line:export-name
 export function activate(context: vscode.ExtensionContext): void {
 
-    const startCommand = vscode.commands.registerCommand('vscode-json-editor.start', () => {
-        JsonEditorPanel.CreateOrShow(context.extensionPath);
+    const startCommand = vscode.commands.registerCommand('vscode-json-editor.start', resource => {
+        if (resource) {
+            if (isOpened(resource)) {
+                // case when there's a resource and it's already opened
+                JsonEditorPanel.CreateOrShow(context.extensionPath);
+            } else {
+                // case when there's a resource but not already opened
+                vscode.window.showTextDocument(resource)
+                    .then(() => {
+                        JsonEditorPanel.CreateOrShow(context.extensionPath);
+                    })
+            }
+        } else {
+            // case when there is no resource passed down
+            JsonEditorPanel.CreateOrShow(context.extensionPath);
+        }
     });
 
     context.subscriptions.push(startCommand);
+}
+
+// Returns true if an editor is already opened for the given resource
+function isOpened(resource) {
+    const openedPaths = vscode.window.visibleTextEditors.map(editor => editor._documentData._uri.path)
+    return openedPaths.includes(resource.path)
 }


### PR DESCRIPTION
I like your extension and I try here to bring my modest contribution.

I added two quick ways to open JSON Editor without typing the command.

- A button `{}` in the top right corner of the editor's title bar when a JSON file is opened in the standard editor.
- A context menu Item on right click of a JSON file in the vscode explorer.

On the context menu, if the file is not opened in a text editor, it's automatically opened alongside with JSON Editor.

The original icon was not showing well when vscode is in dark mode when in the editor title bar, I had to recreate two ones, one for light themes and one for dark themes.

I hope you'll like it...

Best regards